### PR TITLE
🌈 style(tag): update tag display

### DIFF
--- a/src/components/FormattedDate.astro
+++ b/src/components/FormattedDate.astro
@@ -10,7 +10,8 @@ type Props = HTMLAttributes<"time"> & {
 
 const { date, dateTimeOptions, ...attrs } = Astro.props;
 
-const postDate = getFormattedDate(date, dateTimeOptions);
+// Format as YYYY-MM-DD
+const postDate = date.toISOString().split("T")[0];
 ---
 
 <time datetime={date.toISOString()} {...attrs}>

--- a/src/components/FormattedDate.astro
+++ b/src/components/FormattedDate.astro
@@ -10,8 +10,14 @@ type Props = HTMLAttributes<"time"> & {
 
 const { date, dateTimeOptions, ...attrs } = Astro.props;
 
-// Format as YYYY-MM-DD
-const postDate = date.toISOString().split("T")[0];
+// Default to YYYY-MM-DD format if no dateTimeOptions provided
+const defaultOptions: Intl.DateTimeFormatOptions = {
+	year: "numeric",
+	month: "2-digit",
+	day: "2-digit",
+};
+
+const postDate = getFormattedDate(date, dateTimeOptions || defaultOptions);
 ---
 
 <time datetime={date.toISOString()} {...attrs}>

--- a/src/components/blog/Hero.astro
+++ b/src/components/blog/Hero.astro
@@ -78,7 +78,10 @@ const dateTimeOptions: Intl.DateTimeFormatOptions = {
 						class="cactus-link inline-block before:content-['#']"
 						data-pagefind-filter="tag"
 						href={`/tags/${tag}/`}
-					>{tag}</a>{i < data.tags.length - 1 && ", "}
+					>
+						{tag}
+					</a>
+					{i < data.tags.length - 1 && ", "}
 				</>
 			))}
 		</div>

--- a/src/components/blog/Hero.astro
+++ b/src/components/blog/Hero.astro
@@ -75,7 +75,7 @@ const dateTimeOptions: Intl.DateTimeFormatOptions = {
 				<>
 					<a
 						aria-label={`View more blogs with the tag ${tag}`}
-						class="cactus-link inline-block before:content-['#']"
+						class="cactus-link inline-block"
 						data-pagefind-filter="tag"
 						href={`/tags/${tag}/`}
 					>

--- a/src/components/blog/PostPreview.astro
+++ b/src/components/blog/PostPreview.astro
@@ -17,25 +17,25 @@ const postDate = getPostSortDate(post);
 
 <Tag class="grid grid-cols-[120px,1fr] gap-4">
 	<!-- Row 1: Date and Title -->
-	<FormattedDate class="text-gray-600 dark:text-gray-400 text-right" date={postDate} />
+	<FormattedDate class="text-right text-gray-600 dark:text-gray-400" date={postDate} />
 	<div>
 		{post.data.draft && <span class="text-red-500">(Draft) </span>}
 		<a class="cactus-link font-bold" data-astro-prefetch href={`/posts/${post.slug}/`}>
 			{post.data.title}
 		</a>
 	</div>
-	
+
 	<!-- Row 2: Tags and Description -->
 	<div class="text-right">
 		{
 			post.data.tags && post.data.tags.length > 0 && (
-				<div class="flex flex-wrap gap-2 justify-end">
+				<div class="flex flex-wrap justify-end gap-2">
 					{post.data.tags.map((tag: string) => (
 						<a
 							href={`/tags/${tag}`}
 							class="inline-flex items-center rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-800 transition-colors hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
 						>
-							#{tag}
+							{tag}
 						</a>
 					))}
 				</div>
@@ -45,9 +45,7 @@ const postDate = getPostSortDate(post);
 	<div>
 		{
 			withDesc && post.data.description && (
-				<p class="line-clamp-3 italic text-gray-500 dark:text-gray-400">
-					{post.data.description}
-				</p>
+				<p class="line-clamp-3 italic text-gray-500 dark:text-gray-400">{post.data.description}</p>
 			)
 		}
 	</div>

--- a/src/pages/tags/[tag]/[...page].astro
+++ b/src/pages/tags/[tag]/[...page].astro
@@ -53,7 +53,7 @@ const paginationProps = {
 	<h1 class="title mb-6 flex items-center">
 		<a class="text-accent sm:hover:underline" href="/tags/">Tags</a>
 		<span class="me-3 ms-2">→</span>
-		<span class="text-xl">#{tag}</span>
+		<span class="text-xl">{tag}</span>
 	</h1>
 	<section aria-label="Blog post list">
 		<ul class="space-y-8">

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -23,7 +23,7 @@ const meta = {
 						href={`/tags/${tag}/`}
 						title={`View posts with the tag: ${tag}`}
 					>
-						&#35;{tag}
+						{tag}
 					</a>
 					<span class="inline-block">
 						- {val} Post{val > 1 && "s"}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Tags are now displayed without a "#" prefix across the site, including tag lists, post previews, and tag pages.
  - Dates are consistently shown in the "YYYY-MM-DD" format when no custom format is provided.
  - Minor adjustments to class order and formatting improve code readability without affecting the visual layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->